### PR TITLE
The @JavascriptInterface annotation is required in Jelly Bean and later

### DIFF
--- a/NIWebView.java
+++ b/NIWebView.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 
 public class NIWebView extends WebView {
@@ -91,6 +92,7 @@ public class NIWebView extends WebView {
 		}
 		
 		@SuppressWarnings("unused")
+		@JavascriptInterface
 		public void setReturnValue(String returnValue)
 		{
 			this.returnValue = returnValue;
@@ -98,6 +100,7 @@ public class NIWebView extends WebView {
 		}
 		
 		@SuppressWarnings("unused")
+		@JavascriptInterface
 		public void didCompile()
 		{
 			compileLatch.countDown();


### PR DESCRIPTION
If the target API level is JELLY_BEAN_MR1 (SDK version 17) or above, the interface object methods aren't visible to JavaScript unless the [@JavascriptInterface](http://developer.android.com/reference/android/webkit/JavascriptInterface.html) annotation is used.

See also [Binding JavaScript code to Android code](http://developer.android.com/guide/webapps/webview.html#BindingJavaScript) in the WebView documentation.
