### PR TITLE
JavaScript calls occasionally fail

### DIFF
--- a/NIWebView.java
+++ b/NIWebView.java
@@ -54,6 +54,7 @@ public class NIWebView extends WebView {
 					"NISyncInterface.setReturnValue('');" +
 				"}";
 		Log.v(NI_LOG_TAG, finalCode);
+		syncInterface.startLatches();
 		this.loadUrl(finalCode);
 		return syncInterface.getReturnValue();
 	}
@@ -64,12 +65,15 @@ public class NIWebView extends WebView {
 		private CountDownLatch finishLatch;
 		private String returnValue;
 		
+		public void startLatches()
+		{
+			compileLatch = new CountDownLatch(1);
+			finishLatch = new CountDownLatch(1);
+		}
+
 		public String getReturnValue()
 		{
 			returnValue = "";
-			
-			compileLatch = new CountDownLatch(1);
-			finishLatch = new CountDownLatch(1);
 			
 			try {
 				if (compileLatch.await(1, TimeUnit.SECONDS) == false)


### PR DESCRIPTION
It seems that sometimes JavaScript calls `didCompile()` before the latches are created, and the whole call times out on the Java side.
